### PR TITLE
Resolved a couple of warnings related to deprecated items in iOS 6

### DIFF
--- a/Classes/PHFComposeBarView.m
+++ b/Classes/PHFComposeBarView.m
@@ -401,13 +401,10 @@ static CGFloat kTextViewToSuperviewHeightDelta;
         } else if ([_placeholderLabel respondsToSelector:@selector(setMinimumFontSize:)]) {
             // Support dynamic font sizing (minimum font size) functionality in iOS 5 - setMinimumFontSize: was deprecated in iOS 6.
             // When iOS 5 is no longer supported, this can be removed.
-            NSMethodSignature *signature = [_placeholderLabel methodSignatureForSelector:@selector(setMinimumFontSize:)];
-            NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-            [invocation setTarget:_placeholderLabel];
-            [invocation setSelector:@selector(setMinimumFontSize:)];
-            CGFloat fontSize = [UIFont smallSystemFontSize];
-            [invocation setArgument:&fontSize atIndex:([signature numberOfArguments] - 1)];
-            [invocation invoke];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            [_placeholderLabel setMinimumFontSize:[UIFont smallSystemFontSize]];
+#pragma clang diagnostic pop
         }
     }
 


### PR DESCRIPTION
Resolved some warnings related to iOS 6 changes to UILabel.
Note: This code will now require the iOS 6 SDK to build and compile correctly, however it will continue to function correctly on iOS 5, etc.
