### PR TITLE
Fixed the issue with 'charCountLabel' visible also for one line textView, when using a custom font in textView

### DIFF
--- a/Classes/PHFComposeBarView.m
+++ b/Classes/PHFComposeBarView.m
@@ -630,7 +630,8 @@ static CGFloat kTextViewToSuperviewHeightDelta;
 }
 
 - (void)updateCharCountLabel {
-    BOOL isHidden = (_maxCharCount == 0) || [self textHeight] == kTextViewFirstLineHeight;
+    NSInteger linesCount =  (NSInteger)(self.textView.contentSize.height / self.textView.font.lineHeight);
+    BOOL isHidden = (_maxCharCount == 0) || linesCount == 1;
     [[self charCountLabel] setHidden:isHidden];
 
     if (!isHidden) {


### PR DESCRIPTION
It seems like there is an issue with 'charCountLabel' which is visible for one line textView, when custom font is used in 'textView'. See screenshots below (before and after applying a fix introduced in 23dfa0e9ec81f77df54705c836560969d9aba99e :

![screen shot 2014-01-18 at 16 09 36](https://f.cloud.github.com/assets/2694531/1947661/39be5ff0-8061-11e3-8f75-b2e15ecb2ece.png)

![screen shot 2014-01-18 at 16 34 39](https://f.cloud.github.com/assets/2694531/1947663/558e42ea-8061-11e3-9052-f7c65637f597.png)
