### PR TITLE
Remove warning when converting count and maxCharCount to NSString

### DIFF
--- a/Classes/PHFComposeBarView.m
+++ b/Classes/PHFComposeBarView.m
@@ -643,7 +643,7 @@ static CGFloat kTextViewToSuperviewHeightDelta;
 
     if (!isHidden) {
         NSInteger count = [[[[self textView] text] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] length];
-        NSString *text = [NSString stringWithFormat:@"%d/%d", count, [self maxCharCount]];
+        NSString *text = [NSString stringWithFormat:@"%@/%@", [@(count) stringValue], [@([self maxCharCount]) stringValue]];
         [[self charCountLabel] setText:text];
     }
 }


### PR DESCRIPTION
Xcode displayed a warning when count and maxCharCount where converted to long.